### PR TITLE
feat: Ajout d'un script permettant la sauvegarde du storage

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,10 +19,12 @@
     "seed": "node src/jobs/seed/index.js",
     "playground": "node src/jobs/playground/index.js",
     "jobs": "node src/jobs/index.js",
+    "zipStorage": "CERFA_LOG_DESTINATIONS=stderr node src/jobs/zipStorage.js",
     "clear": "node src/jobs/clear/index.js",
     "stats": "node src/jobs/stats/index.js"
   },
   "dependencies": {
+    "archiver": "5.3.0",
     "axios": "0.24.0",
     "body-parser": "1.19.1",
     "boom": "7.3.0",

--- a/server/src/common/mongodb.js
+++ b/server/src/common/mongodb.js
@@ -1,10 +1,12 @@
 const mongoose = require("mongoose");
 const config = require("../config");
 
-let mongooseInstance = mongoose;
+const log = console.error; //Send to diagnostic/error output
+const mongooseInstance = mongoose;
+
 module.exports.connectToMongo = (mongoUri = config.mongodb.uri, mongooseInst = null) => {
   return new Promise((resolve, reject) => {
-    console.log(`MongoDB: Connection to ${mongoUri}`);
+    log(`MongoDB: Connection to ${mongoUri}`);
 
     const mI = mongooseInst || mongooseInstance;
     // Set up default mongoose connection
@@ -20,32 +22,32 @@ module.exports.connectToMongo = (mongoUri = config.mongodb.uri, mongooseInst = n
     const db = mI.connection;
 
     db.on("close", (e) => {
-      console.log("MongoDB", "...close");
+      log("MongoDB", "...close");
       reject(e);
     });
     db.on("error", (err) => {
-      console.error("MongoDB", "Error...error", err);
+      log("MongoDB", "Error...error", err);
       reject(err);
     });
     db.on("disconnect", (err) => {
-      console.log("MongoDB", "...disconnect", err ?? "");
+      log("MongoDB", "...disconnect", err ?? "");
       reject(err);
     });
     db.on("disconnected", (err) => {
-      console.log("MongoDB", "...disconnected", err ?? "");
+      log("MongoDB", "...disconnected", err ?? "");
       reject(err);
     });
     db.on("parseError", (err) => {
-      console.error("MongoDB", "Error...parse", err);
+      log("MongoDB", "Error...parse", err);
       reject(err);
     });
     db.on("timeout", (err) => {
-      console.error("MongoDB", "Error...timeout", err);
+      log("MongoDB", "Error...timeout", err);
       reject(err);
     });
 
     db.once("open", () => {
-      console.log("MongoDB", "Connected");
+      log("MongoDB", "Connected");
       resolve({ db });
     });
   });

--- a/server/src/common/utils/ovhUtils.js
+++ b/server/src/common/utils/ovhUtils.js
@@ -39,17 +39,29 @@ async function authenticate(uri) {
   return { baseUrl, token };
 }
 
-async function requestObjectAccess(path, options) {
+async function requestObjectAccess(path, options = {}) {
   let storage = options.storage || DEFAULT_STORAGE_NAME;
   let { baseUrl, token } = await authenticate(config.ovh.storage.uri);
 
   return {
-    url: encodeURI(`${baseUrl}/${storage}/${path}`),
+    url: encodeURI(`${baseUrl}/${storage}${path === "/" ? "" : `/${path}`}`),
     token,
   };
 }
 
 module.exports = {
+  listStorage: async () => {
+    logger.debug(`Fetching OVH Object Storage file list`);
+    let { url, token } = await requestObjectAccess("/");
+    let response = await axios.get(url, {
+      headers: {
+        "X-Auth-Token": token,
+        Accept: "application/json",
+      },
+    });
+
+    return response.data;
+  },
   getFromStorage: async (path, options = {}) => {
     logger.debug(`Fetching OVH Object Storage file ${path}`);
     let { url, token } = await requestObjectAccess(path, options);

--- a/server/src/jobs/scriptWrapper.js
+++ b/server/src/jobs/scriptWrapper.js
@@ -23,8 +23,8 @@ const createTimer = () => {
     stop: (results) => {
       const duration = moment.utc(new Date().getTime() - launchTime).format("HH:mm:ss.SSS");
       const data = results && results.toJSON ? results.toJSON() : results;
-      data && console.log(JSON.stringify(data || {}, null, 2));
-      console.log(`Completed in ${duration}`);
+      data && logger.info(JSON.stringify(data || {}, null, 2));
+      logger.info(`Completed in ${duration}`);
     },
   };
 };

--- a/server/src/jobs/zipStorage.js
+++ b/server/src/jobs/zipStorage.js
@@ -1,0 +1,23 @@
+const { runScript } = require("./scriptWrapper");
+const { listStorage, getFromStorage } = require("../common/utils/ovhUtils");
+const { oleoduc, writeToStdout } = require("oleoduc");
+const archiver = require("archiver");
+
+runScript(async () => {
+  const list = await listStorage();
+  const archive = archiver("zip", { zlib: { level: 9 } });
+
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i];
+    const isLast = i === list.length - 1;
+    const name = item.name;
+
+    const stream = await getFromStorage(name);
+    archive.append(stream, { name });
+    if (isLast) {
+      archive.finalize();
+    }
+  }
+
+  await oleoduc(archive, writeToStdout());
+});

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -474,6 +474,35 @@ append-transform@^2.0.0:
   dependencies:
     default-require-extensions "^3.0.0"
 
+archiver-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2"
+  integrity sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==
+  dependencies:
+    glob "^7.1.4"
+    graceful-fs "^4.2.0"
+    lazystream "^1.0.0"
+    lodash.defaults "^4.2.0"
+    lodash.difference "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.union "^4.6.0"
+    normalize-path "^3.0.0"
+    readable-stream "^2.0.0"
+
+archiver@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.0.tgz#dd3e097624481741df626267564f7dd8640a45ba"
+  integrity sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==
+  dependencies:
+    archiver-utils "^2.1.0"
+    async "^3.2.0"
+    buffer-crc32 "^0.2.1"
+    readable-stream "^3.6.0"
+    readdir-glob "^1.0.0"
+    tar-stream "^2.2.0"
+    zip-stream "^4.1.0"
+
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
@@ -524,6 +553,11 @@ async@0.9.x:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
+async@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
+  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -711,7 +745,7 @@ bson@^1.1.4:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.5.tgz#2aaae98fcdf6750c0848b0cba1ddec3c73060a34"
   integrity sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==
 
-buffer-crc32@~0.2.3:
+buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
@@ -1013,6 +1047,16 @@ compose-middleware@5.0.1:
     array-flatten "^2.1.2"
     debug "^4.1.0"
 
+compress-commons@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d"
+  integrity sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==
+  dependencies:
+    buffer-crc32 "^0.2.13"
+    crc32-stream "^4.0.2"
+    normalize-path "^3.0.0"
+    readable-stream "^3.6.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1093,13 +1137,21 @@ cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
-crc-32@~1.2.0:
+crc-32@^1.2.0, crc-32@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
   integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
   dependencies:
     exit-on-epipe "~1.0.1"
     printj "~1.1.0"
+
+crc32-stream@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.2.tgz#c922ad22b38395abe9d3870f02fa8134ed709007"
+  integrity sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==
+  dependencies:
+    crc-32 "^1.2.0"
+    readable-stream "^3.4.0"
 
 cross-spawn@^7.0.0:
   version "7.0.3"
@@ -2424,6 +2476,13 @@ latest-version@^5.1.0:
   dependencies:
     package-json "^6.3.0"
 
+lazystream@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638"
+  integrity sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==
+  dependencies:
+    readable-stream "^2.0.5"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -2437,6 +2496,21 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -2487,6 +2561,11 @@ lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+lodash.union@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
+  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
 lodash@4.17.21, lodash@^4.17.21:
   version "4.17.21"
@@ -3706,7 +3785,7 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.3.5:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.5, readable-stream@^2.3.5:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -3719,7 +3798,7 @@ readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.3.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -3727,6 +3806,13 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readdir-glob@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4"
+  integrity sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==
+  dependencies:
+    minimatch "^3.0.4"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -4172,7 +4258,7 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-tar-stream@^2.1.4:
+tar-stream@^2.1.4, tar-stream@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
   integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
@@ -4633,3 +4719,12 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zip-stream@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.0.tgz#51dd326571544e36aa3f756430b313576dc8fc79"
+  integrity sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==
+  dependencies:
+    archiver-utils "^2.1.0"
+    compress-commons "^4.1.0"
+    readable-stream "^3.6.0"


### PR DESCRIPTION
Cette pull-request corrige le logger qui ignorait les destinations.
Les messages de logs ne pouvait donc plus être envoyé vers `stderr` ce qui empêche de pouvoir utiliser la sortie standard dans les scripts

Pour lancer le script

`yarn --silent zipStorage > archive.zip`