### PR TITLE
feat: ajout d'un controle sur les dates de formation et contrat

### DIFF
--- a/ui/modules/Dossier/formEngine/controls/ContratDates.control.js
+++ b/ui/modules/Dossier/formEngine/controls/ContratDates.control.js
@@ -34,19 +34,11 @@ export const ContratDatesControl = [
       const dateDebutContrat = DateTime.fromISO(values.contrat.dateDebutContrat).setLocale("fr-FR");
       const dateDebutFormation = DateTime.fromISO(values.formation.dateDebutFormation).setLocale("fr-FR");
 
-      if (dateDebutContrat < dateDebutFormation.minus({ months: 3 })) {
+      if (dateDebutContrat > dateDebutFormation) {
         return {
-          error: "Le contrat peut commencer au maximum 3 mois avant le début de la formation",
+          error: "Le contrat ne peut pas commencer après le début de la formation",
         };
       }
-    },
-  },
-  {
-    deps: ["contrat.dateDebutContrat", "formation.dateDebutFormation"],
-    process: ({ values }) => {
-      if (!values.contrat.dateDebutContrat || !values.formation.dateDebutFormation) return;
-      const dateDebutContrat = DateTime.fromISO(values.contrat.dateDebutContrat).setLocale("fr-FR");
-      const dateDebutFormation = DateTime.fromISO(values.formation.dateDebutFormation).setLocale("fr-FR");
 
       if (dateDebutContrat < dateDebutFormation.minus({ months: 3 })) {
         return {


### PR DESCRIPTION
Le contrôle sur les 3 mois était déjà implémenté.
Par contre j'ai ajouté ce contrôle: "Le contrat ne peut pas commencer après le début de la formation"
Et suppression d'un contrôle doublons