### PR TITLE
chore: correction chiffrement après ajout habiliation

### DIFF
--- a/.infra/ansible/roles/setup/files/cerfa/tools/gpg/encrypt.sh
+++ b/.infra/ansible/roles/setup/files/cerfa/tools/gpg/encrypt.sh
@@ -3,7 +3,15 @@ set -euo pipefail
 
 readonly RECIPIENTS_KEYS="{{ gpg_keys }}"
 
-function add_recipients() {
+function import_recipients() {
+  IFS=', ' read -r -a keys <<<"${RECIPIENTS_KEYS:-""}"
+
+  for key in "${keys[@]}"; do
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "${key}"
+  done
+}
+
+function add_recipients_as_params() {
   local -n array=$1
   local devops_key
   devops_key="$(cat "/root/.gnupg/publickey.asc" | gpg --quiet --import-options show-only --import --with-colons | grep pub | awk -F ":" '{print $5}')"
@@ -19,7 +27,8 @@ function encrypt() {
   local input=${1:-/dev/stdin}
   local recipients
 
-  add_recipients recipients
+  import_recipients
+  add_recipients_as_params recipients
   gpg \
     --default-key "mna_devops" \
     --encrypt \


### PR DESCRIPTION
Backport d'un bug découvert sur les voeux. Le chiffrement ne fonctionne plus après ajout d'une habitation.
Il faut donc veiller à importer les clés GPG  avant tout chiffrement.